### PR TITLE
geospatial feature use geojson instead of OL Feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,7 @@
   },
   "homepage": "https://github.com/boundlessgeo/spatialconnect-js",
   "dependencies": {
-    "jsdom-jscore": "https://github.com/frankrowe/jsdom-jscore.git",
     "lodash": "3.10.1",
-    "openlayers": "3.9.0",
     "rx": "3.1.2",
     "stream": "0.0.2",
     "uuid": "2.0.1"

--- a/src/sc.geometry.js
+++ b/src/sc.geometry.js
@@ -1,21 +1,12 @@
 'use strict';
 var spatialFeature = require('./sc.spatialfeature');
-if (typeof document === 'undefined') {
-  var jsdom = require('jsdom-jscore');
-  window.document = jsdom.jsdom('<!doctype html><html><body></body></html>');
-  window.Image = function() {};
-}
 var _ = require('lodash');
-var ol = require('openlayers');
 
-var scGeospatialFeature = function(geometry, storeId, spatialfeature) {
+var scGeospatialFeature = function(gj, storeId, spatialfeature) {
   var scGeometry = {};
   Object.setPrototypeOf(scGeometry, spatialFeature(storeId, spatialfeature));
-  scGeometry.geometry = geometry;
 
   scGeometry.serialize = function() {
-    var geojsonFormatter = new ol.format.GeoJSON();
-    var gj = geojsonFormatter.writeFeaturesObject(this.geometry);
     var baseFeature = Object.getPrototypeOf(this).serialize();
     _.merge(gj, baseFeature);
     return gj;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,14 +10,9 @@ module.exports = {
     libraryTarget: 'umd',
     filename: './dist/[name].js'
   },
-  /*  entry : './src/index.js',
-    output : {
-      library : 'spatialconnect',
-      libraryTarget : 'commonjs2',
-      filename : './dist/spatialconnect.js'
-    },*/
   externals: {
-    'ol': 'openlayers'
+    'ol': 'openlayers',
+    'react-native': 'react-native'
   },
   module: {
     loaders: [


### PR DESCRIPTION
Remove openlayers in sc.geometry.js. Now accepts a geojson object instead of OL.Feature object.

Also cleaned up webpack to add react-native as an external.