### PR TITLE
Allow querying with an array of store IDs

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -13,7 +13,6 @@
 'use strict';
 /*global WebViewJavascriptBridge*/
 import Rx from 'rx';
-import { isArray } from 'lodash';
 import { Commands } from './commands';
 import { initialize } from './bridge.js';
 import {

--- a/src/core.js
+++ b/src/core.js
@@ -155,13 +155,11 @@ export const deleteFeature = (featureId) => window.WebViewJavascriptBridge.send(
 });
 
 export const spatialQuery$ = (filter, storeId) => {
-  let c;
-  if (storeId === undefined) {
-    c = Commands.DATASERVICE_SPATIALQUERYALL;
-  } else if (isArray(storeId)) {
-    c = Commands.DATASERVICE_SPATIALQUERYBYIDS;
-  } else {
-    c = Commands.DATASERVICE_SPATIALQUERY;
+  let c = storeId === undefined ? Commands.DATASERVICE_SPATIALQUERYALL : Commands.DATASERVICE_SPATIALQUERY;
+  if (storeId) {
+    if (typeof storeId === 'string') {
+      storeId = [storeId];
+    }
   }
   let responseId = uniqueType(c);
   window.WebViewJavascriptBridge.send({
@@ -176,13 +174,11 @@ export const spatialQuery$ = (filter, storeId) => {
 };
 
 export const geospatialQuery$ = (filter, storeId) => {
-  let c;
-  if (storeId === undefined) {
-    c = Commands.DATASERVICE_GEOSPATIALQUERYALL;
-  } else if (isArray(storeId)) {
-    c = Commands.DATASERVICE_GEOSPATIALQUERYBYIDS;
-  } else {
-    c = Commands.DATASERVICE_GEOSPATIALQUERY;
+  let c = storeId === undefined ? Commands.DATASERVICE_GEOSPATIALQUERYALL : Commands.DATASERVICE_GEOSPATIALQUERY;
+  if (storeId) {
+    if (typeof storeId === 'string') {
+      storeId = [storeId];
+    }
   }
   let responseId = uniqueType(c);
   window.WebViewJavascriptBridge.send({

--- a/src/core.js
+++ b/src/core.js
@@ -13,6 +13,7 @@
 'use strict';
 /*global WebViewJavascriptBridge*/
 import Rx from 'rx';
+import { isArray } from 'lodash';
 import { Commands } from './commands';
 import { initialize } from './bridge.js';
 import {
@@ -154,7 +155,14 @@ export const deleteFeature = (featureId) => window.WebViewJavascriptBridge.send(
 });
 
 export const spatialQuery$ = (filter, storeId) => {
-  let c = storeId === undefined ? Commands.DATASERVICE_SPATIALQUERYALL : Commands.DATASERVICE_SPATIALQUERY;
+  let c;
+  if (storeId === undefined) {
+    c = Commands.DATASERVICE_SPATIALQUERYALL;
+  } else if (isArray(storeId)) {
+    c = Commands.DATASERVICE_SPATIALQUERYBYIDS;
+  } else {
+    c = Commands.DATASERVICE_SPATIALQUERY;
+  }
   let responseId = uniqueType(c);
   window.WebViewJavascriptBridge.send({
     type: c,
@@ -168,7 +176,14 @@ export const spatialQuery$ = (filter, storeId) => {
 };
 
 export const geospatialQuery$ = (filter, storeId) => {
-  let c = storeId === undefined ? Commands.DATASERVICE_GEOSPATIALQUERYALL : Commands.DATASERVICE_GEOSPATIALQUERY;
+  let c;
+  if (storeId === undefined) {
+    c = Commands.DATASERVICE_GEOSPATIALQUERYALL;
+  } else if (isArray(storeId)) {
+    c = Commands.DATASERVICE_GEOSPATIALQUERYBYIDS;
+  } else {
+    c = Commands.DATASERVICE_GEOSPATIALQUERY;
+  }
   let responseId = uniqueType(c);
   window.WebViewJavascriptBridge.send({
     type: c,

--- a/src/core.js
+++ b/src/core.js
@@ -21,6 +21,8 @@ import {
   Platform
 } from 'react-native';
 
+const COMPLETED = '_completed';
+
 initialize(); //initalize bridge
 
 let connectWebViewJavascriptBridge = function (callback) {
@@ -50,8 +52,8 @@ const uniqueType = type => {
 const fromEvent$ = responseId => Rx.Observable.fromEventPattern(
   function addHandler (h) {
     return Platform.OS === 'ios' ?
-      NativeAppEventEmitter.addListener(responseId, h) :
-      DeviceEventEmitter.addListener(responseId, h);
+      NativeAppEventEmitter.addListener(responseId.toString(), h) :
+      DeviceEventEmitter.addListener(responseId.toString(), h);
   },
   function delHandler (_, signal) { signal.remove(); }
 );
@@ -69,21 +71,21 @@ export const xAccessToken$ = () => {
   window.WebViewJavascriptBridge.send({
     type: Commands.AUTHSERVICE_ACCESS_TOKEN
   });
-  return fromEvent$(Commands.AUTHSERVICE_ACCESS_TOKEN.toString());
+  return fromEvent$(Commands.AUTHSERVICE_ACCESS_TOKEN);
 };
 
 export const loginStatus$ = () => {
   window.WebViewJavascriptBridge.send({
     type: Commands.AUTHSERVICE_LOGIN_STATUS
   });
-  return fromEvent$(Commands.AUTHSERVICE_LOGIN_STATUS.toString());
+  return fromEvent$(Commands.AUTHSERVICE_LOGIN_STATUS);
 };
 
 export const notifications$ = () => {
   window.WebViewJavascriptBridge.send({
     type: Commands.NOTIFICATIONS
   });
-  return fromEvent$(Commands.NOTIFICATIONS.toString());
+  return fromEvent$(Commands.NOTIFICATIONS);
 };
 
 export const startAllServices = () => window.WebViewJavascriptBridge.send({
@@ -95,7 +97,7 @@ export const enableGPS = () => {
     type: Commands.SENSORSERVICE_GPS,
     payload: 1
   });
-  return fromEvent$(Commands.SENSORSERVICE_GPS.toString());
+  return fromEvent$(Commands.SENSORSERVICE_GPS);
 };
 
 export const disableGPS = () => window.WebViewJavascriptBridge.send({
@@ -169,7 +171,7 @@ export const spatialQuery$ = (filter, storeId) => {
       storeId: storeId
     }
   });
-  return fromEvent$(responseId);
+  return fromEvent$(responseId).takeUntil(fromEvent$(responseId + COMPLETED));
 };
 
 export const geospatialQuery$ = (filter, storeId) => {
@@ -188,7 +190,7 @@ export const geospatialQuery$ = (filter, storeId) => {
       storeId: storeId
     }
   });
-  return fromEvent$(responseId);
+  return fromEvent$(responseId).takeUntil(fromEvent$(responseId + COMPLETED));
 };
 
 export const getRequest = (url) => {


### PR DESCRIPTION
## Status
**READY**

## JIRA Ticket
SPACON-206

## Description
This allows querying multiple stores specified by an array of store IDs.
```
sc.geospatialQuery$(filter, [
  '3e6c072e-8e62-41be-8d1a-7a3116df9c16',
  'f6dcc750-1349-46b9-a324-0223764d46d1'
]);
```

Single storeIds are added to an array before sending across the bridge. Query methods in native SDKs should always expect storeIds to be an array.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] License

## Steps to Test or Reproduce

```sh
git fetch --all
git checkout <feature_branch> 
npm test
```

@boundlessgeo/spatial-connect
