### PR TITLE
Add bindMapView method

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -18,6 +18,7 @@ import { initialize } from './bridge.js';
 import {
   DeviceEventEmitter,
   NativeAppEventEmitter,
+  NativeModules,
   Platform
 } from 'react-native';
 
@@ -214,6 +215,10 @@ export const postRequest = (url,body) => {
       body : body
     }
   });
+};
+
+export const bindMapView = (node) => {
+  NativeModules.SCBridge.bindMapView(node);
 };
 
 // generic way to send a message to the SpatialConnect bridge


### PR DESCRIPTION
## Status
**READY**

## JIRA Ticket
SPACON-228

## Description
- Add bindMapView method. Takes a react-native node of a MapView instance

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] License

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
git fetch --all
git checkout <feature_branch> 
npm test
```

@boundlessgeo/spatial-connect
