### PR TITLE
bindMapView now takes a callback argument

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spatialconnect",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Javascript Library for Spatial Connect",
   "main": "dist/spatialconnect.js",
   "scripts": {

--- a/src/core.js
+++ b/src/core.js
@@ -333,10 +333,11 @@ export const mqttConnected$ = () => {
 /**
  * Binds the react-native-maps map view reference to the native sdk.
  * @param {object} node native node handle, use findNodeHandle
+ * @param {function} callback callback with first argument as error
  * @example sc.bindMapView(findNodeHandle(this.mapRef));
  */
-export const bindMapView = (node) => {
-  NativeModules.RNSpatialConnect.bindMapView(node);
+export const bindMapView = (node, callback) => {
+  NativeModules.RNSpatialConnect.bindMapView(node, callback);
 };
 
 /**


### PR DESCRIPTION
## Status
**READY**

## Description
- bindMapView now takes a callback as it's second argument, which is called when the map view has been successfully bound to it's native mapView instance

@boundlessgeo/spatial-connect
